### PR TITLE
Change HTTP Tmeouts

### DIFF
--- a/demos/python/sdk_wireless_camera_control/open_gopro/gopro_base.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/gopro_base.py
@@ -32,9 +32,9 @@ from open_gopro.responses import GoProResp
 
 logger = logging.getLogger(__name__)
 
-WRITE_TIMEOUT: Final = 5
-GET_TIMEOUT: Final = 5
-HTTP_GET_RETRIES: Final = 5
+WRITE_TIMEOUT: Final = 1
+GET_TIMEOUT: Final = 1
+HTTP_GET_RETRIES: Final = 1
 
 GoPro = TypeVar("GoPro", bound="GoProBase")
 ApiType = TypeVar("ApiType", WiredApi, WirelessApi)


### PR DESCRIPTION
### Description

Reduce HTTP timeout and retries from 5 sec and 5 tries to 1 sec and 1 try.

### Reason

Allows faster detection of a disconnected camera, instead of API calls blocking for a long period of time.

### Method / Design

Changed constants in gopro base class.

### Testing

Tested application with the updated library and confirmed API calls time out in the correct amount of time when a camera is not connected.