### PR TITLE
Add Definition for Media Format 12

### DIFF
--- a/demos/python/sdk_wireless_camera_control/open_gopro/api/params.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/api/params.py
@@ -364,6 +364,7 @@ class PerformanceMode(GoProEnum):
 
 
 class MediaFormat(GoProEnum):
+    UNKNOWN = 12
     TIME_LAPSE_VIDEO = 13
     TIME_LAPSE_PHOTO = 20
     NIGHT_LAPSE_PHOTO = 21


### PR DESCRIPTION
### Description

Add a definition for media format 12, to prevent error messages when the camera reports this format.

### Reason

The SDK does not have a definition for media format 12, despite the camera returning this value during normal operation. This causes numerous error messages saying `MEDIA_FORMAT does not contain a value 12`.

### Method / Design

Added a value `UNKNOWN = 12` to the `MediaFormat` class. Format 12 appears to mean "normal" recording (the other values correspond to time lapse or night lapse modes), but it is not actually defined in any gopro documentation.

### Testing

Ran application with the modified library and confirmed error messages are no longer present.