### PR TITLE
Modify Logging Setup

### DIFF
--- a/demos/python/sdk_wireless_camera_control/open_gopro/gopro_base.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/gopro_base.py
@@ -371,7 +371,7 @@ class GoProBase(ABC, Generic[ApiType]):
                 logger.critical(f"Unexpected error: {repr(e)}")
             else:
                 pass
-            logger.warning("Retrying to send the command...")
+            logger.debug("Retrying to send the command...")
         else:
             raise GpException.ResponseTimeout(HTTP_GET_RETRIES)
 

--- a/demos/python/sdk_wireless_camera_control/open_gopro/util.py
+++ b/demos/python/sdk_wireless_camera_control/open_gopro/util.py
@@ -86,6 +86,11 @@ class Logger:
         http_client.HTTPConnection.debuglevel = 1
         http_client.print = lambda *args: logging.getLogger("http.client").debug(" ".join(args))  # type: ignore
 
+        # Enable / disable logging in modules
+        for module, level in self.modules.items():
+            l = logging.getLogger(module)
+            l.setLevel(level)
+
         self.file_handler: Optional[logging.Handler]
         if output:
             # Logging to file with millisecond timing
@@ -102,15 +107,15 @@ class Logger:
             self.file_handler = None
 
         # Use Rich for colorful console logging
-        self.stream_handler = RichHandler(rich_tracebacks=True, enable_link_path=True, show_time=False)
-        stream_formatter = logging.Formatter("%(asctime)s.%(msecs)03d %(message)s", datefmt="%H:%M:%S")
-        self.stream_handler.setFormatter(stream_formatter)
-        self.stream_handler.setLevel(logging.INFO)
-        logger.addHandler(self.stream_handler)
-        self.addLoggingHandler(self.stream_handler)
+        # self.stream_handler = RichHandler(rich_tracebacks=True, enable_link_path=True, show_time=False)
+        # stream_formatter = logging.Formatter("%(asctime)s.%(msecs)03d %(message)s", datefmt="%H:%M:%S")
+        # self.stream_handler.setFormatter(stream_formatter)
+        # self.stream_handler.setLevel(logging.INFO)
+        # logger.addHandler(self.stream_handler)
+        # self.addLoggingHandler(self.stream_handler)
 
-        self.addLoggingLevel("TRACE", logging.DEBUG - 5)
-        logger.setLevel(logging.TRACE)  # type: ignore # pylint: disable=no-member
+        # self.addLoggingLevel("TRACE", logging.DEBUG - 5)
+        # logger.setLevel(logging.TRACE)  # type: ignore # pylint: disable=no-member
 
         traceback.install()  # Enable exception tracebacks in rich logger
 


### PR DESCRIPTION
### Description
Modify logging setup so it does not override settings of external logger. Change log level of some statements.

### Reason
Allows use of pre-configured external logger and reduces log noise.

### Method / Design
Commented out code in logging setup that always inits a stream logger by default, so the existing file logger can be used alone. Added config of per-module log levels to logging setup function, so it happens even when an external logger is used.

Moved log level of some statements from `debug` to `info` to reduce excessive log output.

### Testing
Installed modified library using `pip` and ran application. Confirmed that logging behavior was as expected.
